### PR TITLE
Remove H2 and run all tests against real PostgreSQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,13 +69,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- testImplementation 'com.h2database:h2' -->
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-restclient</artifactId>

--- a/src/test/java/dev/jgrecu/cashcard/CashCardApplicationTests.java
+++ b/src/test/java/dev/jgrecu/cashcard/CashCardApplicationTests.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -20,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureTestRestTemplate
+@Import(TestcontainersConfiguration.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class CashCardApplicationTests {
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,8 +1,3 @@
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-
 spring.sql.init.mode=never
 
 spring.flyway.enabled=true


### PR DESCRIPTION
## Summary
- Remove H2 dependency entirely
- All 42 tests now run against a real PostgreSQL container via Testcontainers
- Remove H2 datasource config from test application.properties

## Test plan
- [x] All 42 tests pass (`mvn clean test`)
- [x] Verify CI passes (requires Docker/Podman)