### PR TITLE
Add Dockerfile and Docker Compose for containerized deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+target/
+!target/*.jar
+.git
+.gitignore
+.idea
+*.iml
+*.md
+docker-compose.yaml
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM eclipse-temurin:25-jdk-alpine AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src src
+RUN --mount=type=cache,target=/root/.m2 \
+    apk add --no-cache maven && \
+    mvn package -DskipTests -q && \
+    java -Djarmode=tools -jar target/*.jar extract --destination target/extracted
+
+FROM eclipse-temurin:25-jre-alpine AS runtime
+WORKDIR /app
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+COPY --from=build /app/target/extracted/lib/ ./lib/
+COPY --from=build /app/target/extracted/*.jar ./app.jar
+
+RUN chown -R appuser:appgroup /app
+USER appuser
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ A RESTful API service for managing family cash cards -- digital debit cards desi
 - **Authentication & Authorization** -- HTTP Basic authentication with role-based access control (Spring Security)
 - **Owner Isolation** -- Users can only access their own cash cards
 - **Pagination & Sorting** -- Configurable pagination with default sorting by amount
-- **Data Persistence** -- Spring Data JDBC with PostgreSQL (H2 for testing)
+- **Data Persistence** -- Spring Data JDBC with PostgreSQL
+- **Database Migrations** -- Flyway for versioned schema management
+- **Integration Testing** -- Testcontainers with real PostgreSQL instances
 
 ## Tech Stack
 
@@ -19,7 +21,8 @@ A RESTful API service for managing family cash cards -- digital debit cards desi
 | Security        | Spring Security         |
 | Data Access     | Spring Data JDBC        |
 | Database        | PostgreSQL              |
-| Test Database   | H2 (in-memory)         |
+| Migrations      | Flyway                  |
+| Testing         | Testcontainers (PostgreSQL) |
 | Build Tool      | Maven                   |
 
 ## API Endpoints
@@ -38,6 +41,7 @@ A RESTful API service for managing family cash cards -- digital debit cards desi
 
 - Java 25+
 - Maven 3.9+
+- Docker or Podman (for tests)
 - PostgreSQL (for production)
 
 ### Build & Test

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A RESTful API service for managing family cash cards -- digital debit cards desi
 | Migrations      | Flyway                  |
 | Testing         | Testcontainers (PostgreSQL) |
 | Build Tool      | Maven                   |
+| Containerization| Docker (multi-stage build) |
 
 ## API Endpoints
 
@@ -50,11 +51,35 @@ A RESTful API service for managing family cash cards -- digital debit cards desi
 mvn clean package
 ```
 
-### Run
+### Run locally
 
 ```bash
 mvn spring-boot:run
 ```
+
+Requires a PostgreSQL instance on `localhost:5432` with a `cashcard` database.
+
+### Run with Docker Compose
+
+```bash
+docker compose up -d
+```
+
+Starts both the application and PostgreSQL. The API is available at `http://localhost:8080`.
+
+To stop and remove everything:
+
+```bash
+docker compose down -v
+```
+
+### Environment Variables
+
+| Variable      | Default                                      | Description         |
+|---------------|----------------------------------------------|---------------------|
+| `DB_URL`      | `jdbc:postgresql://localhost:5432/cashcard`   | JDBC connection URL |
+| `DB_USERNAME` | `postgres`                                   | Database username   |
+| `DB_PASSWORD` | `postgres`                                   | Database password   |
 
 ## License
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,31 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      DB_URL: jdbc:postgresql://db:5432/cashcard
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:17-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: cashcard
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d cashcard"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  pgdata:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/cashcard
-spring.datasource.username=postgres
-spring.datasource.password=postgres
+spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/cashcard}
+spring.datasource.username=${DB_USERNAME:postgres}
+spring.datasource.password=${DB_PASSWORD:postgres}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.flyway.enabled=true


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfile (JDK Alpine build, JRE Alpine runtime ~289MB)
- Add docker-compose.yaml with app + PostgreSQL services
- Add .dockerignore for minimal build context
- Make datasource configurable via environment variables (`DB_URL`, `DB_USERNAME`, `DB_PASSWORD`)
- Update README with Docker Compose usage and environment variables table

## Test plan
- [x] All 42 tests pass (`mvn clean test`)
- [x] Docker image builds successfully
- [x] `docker compose up` starts app and PostgreSQL, API responds correctly